### PR TITLE
Add genotype distribution analysis pipeline

### DIFF
--- a/analyze_aims.py
+++ b/analyze_aims.py
@@ -120,7 +120,7 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genot
     position_results = {}
     for _, row in geno.iterrows():
         position = row["pos"]
-        vals = row[samples].values
+        vals = pd.to_numeric(row[samples], errors="coerce").to_numpy()
         vals = vals[~np.isnan(vals)]
         if vals.size == 0:
             position_results[position] = {"error": "no genotype values"}

--- a/analyze_aims.py
+++ b/analyze_aims.py
@@ -23,6 +23,8 @@ import json
 import numpy as np
 import pandas as pd
 from scipy import stats
+import matplotlib
+matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 
 
@@ -108,7 +110,8 @@ def fit_distributions(values: np.ndarray):
     return best_name, dist_obj, params
 
 
-def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genotypes: str, outdir: Path):
+def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame,
+                       genotypes: str, outdir: Path, make_plots: bool):
     """Analyze genotype distributions for all samples belonging to a population."""
     samples = labels.loc[labels["pop"] == pop, "sample"].tolist()
     pop_positions = aims.loc[aims["pop"] == pop, "pos"].tolist()
@@ -123,11 +126,13 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genot
     positions = geno.index.tolist()
 
     pop_outdir = outdir / pop
-    pop_outdir.mkdir(parents=True, exist_ok=True)
+    if make_plots:
+        pop_outdir.mkdir(parents=True, exist_ok=True)
 
     # Plot genotype values for each sample across AIM positions and fit individual distributions
     sample_results = {}
-    fig_all, ax_all = plt.subplots()
+    if make_plots:
+        fig_all, ax_all = plt.subplots()
     for sample in samples:
         vals = pd.to_numeric(geno[sample], errors="coerce").to_numpy()
         idx = np.arange(len(positions))
@@ -140,36 +145,42 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genot
 
         best_name_s, _, params_s = fit_distributions(vals)
 
-        fig, ax = plt.subplots()
-        ax.plot(idx_masked, vals, marker="o")
-        ax.set_xticks(idx)
-        ax.set_xticklabels(positions, rotation=90, fontsize=6)
-        ax.set_xlabel("AIM position")
-        ax.set_ylabel("Genotype value")
-        ax.set_title(f"{sample} values in {pop} AIMs")
-        fig.tight_layout()
-        sample_plot = pop_outdir / f"{sample}_values.png"
-        fig.savefig(sample_plot)
-        plt.close(fig)
-
-        ax_all.plot(idx_masked, vals, marker="o", alpha=0.3)
+        if make_plots:
+            fig, ax = plt.subplots()
+            ax.plot(idx_masked, vals, marker="o")
+            ax.set_xticks(idx)
+            ax.set_xticklabels(positions, rotation=90, fontsize=6)
+            ax.set_xlabel("AIM position")
+            ax.set_ylabel("Genotype value")
+            ax.set_title(f"{sample} values in {pop} AIMs")
+            fig.tight_layout()
+            sample_plot = pop_outdir / f"{sample}_values.png"
+            fig.savefig(sample_plot)
+            plt.close(fig)
+            ax_all.plot(idx_masked, vals, marker="o", alpha=0.3)
+            plot_path = str(sample_plot)
+        else:
+            plot_path = None
 
         sample_results[sample] = {
             "distribution": best_name_s,
             "params": params_s,
-            "plot": str(sample_plot),
+            "plot": plot_path,
             "values": int(vals.size),
         }
 
-    ax_all.set_xticks(np.arange(len(positions)))
-    ax_all.set_xticklabels(positions, rotation=90, fontsize=6)
-    ax_all.set_xlabel("AIM position")
-    ax_all.set_ylabel("Genotype value")
-    ax_all.set_title(f"{pop} sample genotype values")
-    fig_all.tight_layout()
-    all_plot_path = pop_outdir / "all_sample_values.png"
-    fig_all.savefig(all_plot_path)
-    plt.close(fig_all)
+    if make_plots:
+        ax_all.set_xticks(np.arange(len(positions)))
+        ax_all.set_xticklabels(positions, rotation=90, fontsize=6)
+        ax_all.set_xlabel("AIM position")
+        ax_all.set_ylabel("Genotype value")
+        ax_all.set_title(f"{pop} sample genotype values")
+        fig_all.tight_layout()
+        all_plot_path = pop_outdir / "all_sample_values.png"
+        fig_all.savefig(all_plot_path)
+        plt.close(fig_all)
+    else:
+        all_plot_path = None
 
     # Pool genotype values across all AIM positions and samples for population-level distribution
     values = pd.to_numeric(geno[samples], errors="coerce").to_numpy().ravel()
@@ -179,22 +190,25 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genot
 
     best_name, dist_obj, params = fit_distributions(values)
 
-    fig, ax = plt.subplots()
-    bins = np.arange(values.min(), values.max() + 2) - 0.5
-    ax.hist(values, bins=bins, density=True, alpha=0.6, label="data")
-    if isinstance(dist_obj.dist, stats.rv_discrete):
-        xk = np.arange(values.min(), values.max() + 1)
-        ax.plot(xk, dist_obj.pmf(xk), "r-", label=f"{best_name} fit")
+    if make_plots:
+        fig, ax = plt.subplots()
+        bins = np.arange(values.min(), values.max() + 2) - 0.5
+        ax.hist(values, bins=bins, density=True, alpha=0.6, label="data")
+        if isinstance(dist_obj.dist, stats.rv_discrete):
+            xk = np.arange(values.min(), values.max() + 1)
+            ax.plot(xk, dist_obj.pmf(xk), "r-", label=f"{best_name} fit")
+        else:
+            x = np.linspace(values.min(), values.max(), 100)
+            ax.plot(x, dist_obj.pdf(x), "r-", label=f"{best_name} fit")
+        ax.set_title(f"{pop} genotype distribution across AIMs")
+        ax.set_xlabel("Genotype value")
+        ax.set_ylabel("Density")
+        ax.legend()
+        plot_path = pop_outdir / "aggregate_distribution.png"
+        fig.savefig(plot_path)
+        plt.close(fig)
     else:
-        x = np.linspace(values.min(), values.max(), 100)
-        ax.plot(x, dist_obj.pdf(x), "r-", label=f"{best_name} fit")
-    ax.set_title(f"{pop} genotype distribution across AIMs")
-    ax.set_xlabel("Genotype value")
-    ax.set_ylabel("Density")
-    ax.legend()
-    plot_path = pop_outdir / "aggregate_distribution.png"
-    fig.savefig(plot_path)
-    plt.close(fig)
+        plot_path = None
 
     # Build genotype sequence distribution for the population.
     sample_vectors = geno[samples].T
@@ -207,11 +221,11 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genot
     return {
         "distribution": best_name,
         "params": params,
-        "plot": str(plot_path),
+        "plot": str(plot_path) if plot_path else None,
         "values": int(values.size),
         "sequence_counts": seq_counts,
         "sample_results": sample_results,
-        "all_samples_plot": str(all_plot_path),
+        "all_samples_plot": str(all_plot_path) if all_plot_path else None,
     }
 
 
@@ -223,15 +237,20 @@ def main():
     ap.add_argument("--population", help="Specific population to analyze")
     ap.add_argument("--outdir", default="plots", help="Output directory for plots")
     ap.add_argument("--threads", type=int, default=4, help="Number of threads")
+    ap.add_argument("--plots", action="store_true", help="Generate plots in addition to summaries")
     args = ap.parse_args()
 
     labels, mapping = build_pop_mapping(args.labels)
     aims = load_aims(args.aims, mapping)
     pops = [args.population] if args.population else sorted(labels["pop"].unique())
     outdir = Path(args.outdir)
+    outdir.mkdir(parents=True, exist_ok=True)
     results = {}
     with cf.ThreadPoolExecutor(max_workers=args.threads) as ex:
-        futs = {ex.submit(analyze_population, pop, labels, aims, args.genotypes, outdir): pop for pop in pops}
+        futs = {
+            ex.submit(analyze_population, pop, labels, aims, args.genotypes, outdir, args.plots): pop
+            for pop in pops
+        }
         for fut in cf.as_completed(futs):
             pop = futs[fut]
             try:

--- a/analyze_aims.py
+++ b/analyze_aims.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Analyze genotype distributions for population-specific AIM positions.
+
+This script loads genotype data, AIM positions, and sample labels to
+identify the best-fitting statistical distribution for genotype values of
+specific populations at their ancestry-informative markers (AIMs).
+
+Usage example:
+    python analyze_aims.py --genotypes head_train_samples.csv --aims G_const_infs.csv --labels train1.labels
+    # optionally add --population ESN to limit the analysis to a single group
+"""
+import argparse
+import concurrent.futures as cf
+from pathlib import Path
+import json
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+import matplotlib.pyplot as plt
+
+
+EXPECTED_POPS = [
+    "ACB", "ASW", "BEB", "CDX", "CEU", "CHB", "CHS", "CLM",
+    "ESN", "FIN", "GBR", "GIH", "GWD", "IBS", "ITU", "JPT",
+    "KHV", "LWK", "MSL", "MXL", "PEL", "PJL", "PUR", "STU",
+    "TSI", "YRI",
+]
+
+
+def build_pop_mapping(labels_file: str):
+    """Return (labels_df, mapping from P(Gi) to population).
+
+    The mapping aligns AIM population codes P(G0) .. P(G25) with the
+    alphabetically sorted populations from the training labels.
+    """
+    labels = pd.read_csv(labels_file, sep="\t", names=["sample", "pop"])
+    pops = sorted(labels["pop"].unique())
+    if pops != EXPECTED_POPS:
+        raise ValueError("labels populations do not match expected order")
+    mapping = {f"P(G{i})": pop for i, pop in enumerate(pops)}
+    return labels, mapping
+
+
+def load_aims(aim_file: str, mapping):
+    aims = pd.read_csv(aim_file)
+    pop_codes = aims["pop"]
+    aims["pop"] = pop_codes.map(mapping)
+    if aims["pop"].isnull().any():
+        unknown = pop_codes[aims["pop"].isnull()].unique()
+        raise ValueError(f"unknown AIM population codes: {unknown}")
+    aims["pos"] = aims["chromosome"].str.replace("chr", "", regex=False) + "_" + aims["position"].astype(str)
+    return aims
+
+
+def fit_distributions(values: np.ndarray):
+    """Fit candidate distributions and return best name, scipy dist, and parameters."""
+    if values.size == 0:
+        raise ValueError("no genotype values to fit")
+    values = values.astype(float)
+    candidates = {}
+    # Binomial (n=2)
+    p = np.clip(values.mean() / 2, 1e-6, 1 - 1e-6)
+    candidates["binomial"] = (
+        stats.binom(n=2, p=p),
+        {"n": 2, "p": float(p)},
+        stats.binom.logpmf(values, 2, p).sum(),
+    )
+    # Poisson
+    lam = values.mean()
+    candidates["poisson"] = (
+        stats.poisson(mu=lam),
+        {"mu": float(lam)},
+        stats.poisson.logpmf(values, lam).sum(),
+    )
+    # Normal
+    mu, sigma = stats.norm.fit(values)
+    candidates["normal"] = (
+        stats.norm(loc=mu, scale=sigma),
+        {"loc": float(mu), "scale": float(sigma)},
+        stats.norm.logpdf(values, mu, sigma).sum(),
+    )
+    # Uniform
+    a, b = values.min(), values.max()
+    scale = max(b - a, 1e-6)
+    candidates["uniform"] = (
+        stats.uniform(loc=a, scale=scale),
+        {"loc": float(a), "scale": float(scale)},
+        stats.uniform.logpdf(values, a, scale).sum(),
+    )
+    # Exponential
+    loc, scale = stats.expon.fit(values, floc=0)
+    candidates["exponential"] = (
+        stats.expon(loc=loc, scale=scale),
+        {"loc": float(loc), "scale": float(scale)},
+        stats.expon.logpdf(values, loc, scale).sum(),
+    )
+    # Select best by log-likelihood
+    best_name, (dist_obj, params, _) = max(candidates.items(), key=lambda kv: kv[1][2])
+    return best_name, dist_obj, params
+
+
+def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame, genotypes: str, outdir: Path):
+    samples = labels.loc[labels["pop"] == pop, "sample"].tolist()
+    pop_positions = aims.loc[aims["pop"] == pop, "pos"].tolist()
+    usecols = ["pos"] + samples
+    geno = pd.read_csv(genotypes, sep="\t", usecols=lambda c: c in usecols)
+    geno = geno[geno["pos"].isin(pop_positions)]
+    if geno.empty:
+        raise ValueError("no genotype data for population")
+    values = geno[samples].values.ravel()
+    values = values[~np.isnan(values)]
+    if values.size == 0:
+        raise ValueError("no genotype values for population")
+    best_name, dist_obj, params = fit_distributions(values)
+    # Plot histogram and fitted distribution
+    outdir.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots()
+    bins = np.arange(values.min(), values.max() + 2) - 0.5
+    ax.hist(values, bins=bins, density=True, alpha=0.6, label="data")
+    if isinstance(dist_obj.dist, stats.rv_discrete):
+        xk = np.arange(values.min(), values.max() + 1)
+        ax.plot(xk, dist_obj.pmf(xk), "r-", label=f"{best_name} fit")
+    else:
+        x = np.linspace(values.min(), values.max(), 100)
+        ax.plot(x, dist_obj.pdf(x), "r-", label=f"{best_name} fit")
+    ax.set_title(f"{pop} genotype distribution")
+    ax.set_xlabel("Genotype value")
+    ax.set_ylabel("Density")
+    ax.legend()
+    plot_path = outdir / f"{pop}_distribution.png"
+    fig.savefig(plot_path)
+    plt.close(fig)
+    return best_name, params, plot_path, len(values)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Analyze genotype distributions by population")
+    ap.add_argument("--genotypes", required=True, help="Genotype CSV file")
+    ap.add_argument("--aims", required=True, help="AIM positions CSV file")
+    ap.add_argument("--labels", required=True, help="Sample labels file")
+    ap.add_argument("--population", help="Specific population to analyze")
+    ap.add_argument("--outdir", default="plots", help="Output directory for plots")
+    ap.add_argument("--threads", type=int, default=4, help="Number of threads")
+    args = ap.parse_args()
+
+    labels, mapping = build_pop_mapping(args.labels)
+    aims = load_aims(args.aims, mapping)
+    pops = [args.population] if args.population else sorted(labels["pop"].unique())
+    outdir = Path(args.outdir)
+    results = {}
+    with cf.ThreadPoolExecutor(max_workers=args.threads) as ex:
+        futs = {ex.submit(analyze_population, pop, labels, aims, args.genotypes, outdir): pop for pop in pops}
+        for fut in cf.as_completed(futs):
+            pop = futs[fut]
+            try:
+                dist, params, plot_path, n = fut.result()
+                results[pop] = {
+                    "distribution": dist,
+                    "params": params,
+                    "plot": str(plot_path),
+                    "values": n,
+                }
+            except Exception as exc:
+                results[pop] = {"error": str(exc)}
+    for pop, data in sorted(results.items()):
+        if "error" in data:
+            print(f"{pop}: error {data['error']}")
+        else:
+            print(
+                f"{pop}: best distribution {data['distribution']} using {data['values']} values; plot -> {data['plot']}"
+            )
+    summary_path = outdir / "distribution_summary.json"
+    with summary_path.open("w") as fh:
+        json.dump(results, fh, indent=2)
+    print(f"summary JSON -> {summary_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/analyze_aims.py
+++ b/analyze_aims.py
@@ -134,7 +134,7 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame,
     if make_plots:
         fig_all, ax_all = plt.subplots()
     for sample in samples:
-        vals = pd.to_numeric(geno[sample], errors="coerce").to_numpy()
+        vals = pd.to_numeric(geno[sample].to_numpy(), errors="coerce")
         idx = np.arange(len(positions))
         mask = ~np.isnan(vals)
         vals = vals[mask]
@@ -183,7 +183,7 @@ def analyze_population(pop: str, labels: pd.DataFrame, aims: pd.DataFrame,
         all_plot_path = None
 
     # Pool genotype values across all AIM positions and samples for population-level distribution
-    values = pd.to_numeric(geno[samples], errors="coerce").to_numpy().ravel()
+    values = pd.to_numeric(geno[samples].to_numpy().ravel(), errors="coerce")
     values = values[~np.isnan(values)]
     if values.size == 0:
         raise ValueError("no genotype values to fit")

--- a/analyze_aims.py
+++ b/analyze_aims.py
@@ -79,6 +79,7 @@ def fit_distributions(values: np.ndarray):
     )
     # Normal
     mu, sigma = stats.norm.fit(values)
+    sigma = max(sigma, 1e-6)
     candidates["normal"] = (
         stats.norm(loc=mu, scale=sigma),
         {"loc": float(mu), "scale": float(sigma)},
@@ -94,6 +95,7 @@ def fit_distributions(values: np.ndarray):
     )
     # Exponential
     loc, scale = stats.expon.fit(values, floc=0)
+    scale = max(scale, 1e-6)
     candidates["exponential"] = (
         stats.expon(loc=loc, scale=scale),
         {"loc": float(loc), "scale": float(scale)},

--- a/run_analysis.sh
+++ b/run_analysis.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Run genotype distribution analysis.
+# By default all populations are processed; pass a population code as the
+# sixth argument to limit the analysis.
+set -euo pipefail
+
+GENO=${1:-head_train_samples.csv}
+AIMS=${2:-G_const_infs.csv}
+LABELS=${3:-train1.labels}
+OUTDIR=${4:-analysis_plots}
+THREADS=${5:-$(nproc)}
+POP=${6:-}
+
+if [[ -n "$POP" ]]; then
+  python analyze_aims.py --genotypes "$GENO" --aims "$AIMS" --labels "$LABELS" \
+    --population "$POP" --outdir "$OUTDIR" --threads "$THREADS"
+else
+  python analyze_aims.py --genotypes "$GENO" --aims "$AIMS" --labels "$LABELS" \
+    --outdir "$OUTDIR" --threads "$THREADS"
+fi
+

--- a/run_analysis.sh
+++ b/run_analysis.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Run genotype distribution analysis.
 # By default all populations are processed; pass a population code as the
-# sixth argument to limit the analysis.
+# sixth argument to limit the analysis.  Provide any value as a seventh
+# argument to also generate plots.
 set -euo pipefail
 
 GENO=${1:-head_train_samples.csv}
@@ -10,12 +11,19 @@ LABELS=${3:-train1.labels}
 OUTDIR=${4:-analysis_plots}
 THREADS=${5:-$(nproc)}
 POP=${6:-}
+PLOTS=${7:-}
+
+if [[ -n "$PLOTS" ]]; then
+  PLOTS_FLAG="--plots"
+else
+  PLOTS_FLAG=""
+fi
 
 if [[ -n "$POP" ]]; then
   python analyze_aims.py --genotypes "$GENO" --aims "$AIMS" --labels "$LABELS" \
-    --population "$POP" --outdir "$OUTDIR" --threads "$THREADS"
+    --population "$POP" --outdir "$OUTDIR" --threads "$THREADS" $PLOTS_FLAG
 else
   python analyze_aims.py --genotypes "$GENO" --aims "$AIMS" --labels "$LABELS" \
-    --outdir "$OUTDIR" --threads "$THREADS"
+    --outdir "$OUTDIR" --threads "$THREADS" $PLOTS_FLAG
 fi
 


### PR DESCRIPTION
## Summary
- fit and select statistical distributions for each population's AIM genotype values, returning parameters for later sampling and classification
- write per-population distribution metadata to `distribution_summary.json` and generate histogram plots
- update wrapper script to analyze all populations by default, with an optional population argument
- fix plotting by distinguishing discrete vs continuous distributions and closing figures after saving

## Testing
- `pip install numpy pandas scipy matplotlib` *(fails: Could not find a version that satisfies the requirement numpy (ProxyError: Tunnel connection failed: 403 Forbidden))*
- `bash run_analysis.sh` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_689c58816f848324ba42085448145d93